### PR TITLE
Remove Colorama auto-reset which interferes with many other curses apps

### DIFF
--- a/backtrace.py
+++ b/backtrace.py
@@ -166,8 +166,10 @@ def hook(reverse=False,
 
         tpe = tpe if isinstance(tpe, str) else tpe.__name__
         tb_message = styles['backtrace'].format('Traceback ({0}):'.format(
-            'Most recent call ' + ('first' if reverse else 'last'))) + Style.RESET_ALL
-        err_message = styles['error'].format(tpe + ': ' + str(value)) + Style.RESET_ALL
+            'Most recent call ' + ('first' if reverse else 'last'))) + \
+            Style.RESET_ALL
+        err_message = styles['error'].format(tpe + ': ' + str(value)) + \
+            Style.RESET_ALL
 
         if reverse:
             parser.reverse()

--- a/backtrace.py
+++ b/backtrace.py
@@ -153,7 +153,7 @@ def hook(reverse=False,
         styles = STYLES
 
     # For Windows
-    colorama.init(autoreset=True)
+    colorama.init()
 
     def backtrace_excepthook(tpe, value, tb=None):
         # Don't know if we're getting traceback or traceback entries.
@@ -166,8 +166,8 @@ def hook(reverse=False,
 
         tpe = tpe if isinstance(tpe, str) else tpe.__name__
         tb_message = styles['backtrace'].format('Traceback ({0}):'.format(
-            'Most recent call ' + ('first' if reverse else 'last')))
-        err_message = styles['error'].format(tpe + ': ' + str(value))
+            'Most recent call ' + ('first' if reverse else 'last'))) + Style.RESET_ALL
+        err_message = styles['error'].format(tpe + ': ' + str(value)) + Style.RESET_ALL
 
         if reverse:
             parser.reverse()


### PR DESCRIPTION
Colorama auto-reset causes the normal behavior of the terminal to change significantly, which causes other curses applications, such as pudb to not be able to display color.  Auto-reset is not necessary, however, there were a couple of instances where colors were not reset.  I added in color resets there and the behavior appears identical.